### PR TITLE
Remove PHP 8 support due to lack of PHP extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,6 @@ jobs:
 
         php:
           - 7.4
-          - 8.0
-          - 8.1
 
     steps:
       - name: Checkout

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -34,7 +34,7 @@ jobs:
           - windows-latest
 
         php:
-          - 8.1
+          - 7.4
 
     steps:
       - name: Checkout

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,8 +34,6 @@ jobs:
 
         php:
           - 7.4
-          - 8.0
-          - 8.1
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Yii WinCache Change Log
 
-
 ## 1.0.1 under development
 
-- no changes in this release.
+- Bug #31: Remove PHP 8 support due to lack of PHP extension (devanych)
 
 ## 1.0.0 February 02, 2021
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This package uses the PHP [Windows Cache](https://sourceforge.net/projects/winca
 ([see also](https://www.php.net/manual/book.wincache.php)) extension and implements
 [PSR-16](https://www.php-fig.org/psr/psr-16/) cache.
 
+## Requirements
+
+- PHP 7.4.
+- `WinCache` PHP extension.
+
 ## Installation
 
 The package could be installed with composer:
@@ -66,6 +71,8 @@ To work with values in a more efficient manner, batch operations should be used:
 - `deleteMultiple()`
 
 This package can be used as a cache handler for the [Yii Caching Library](https://github.com/yiisoft/cache).
+
+## Testing
 
 ### Unit testing
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "source": "https://github.com/yiisoft/cache-wincache"
     },
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4",
         "ext-wincache": "*",
         "psr/simple-cache": "^1.0.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Remove PHP 8 support, since the latest version of the extension only supports PHP 7.4:

https://sourceforge.net/projects/wincache

https://pecl.php.net/package/wincache