### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    groups:
-      github-actions:
-        patterns:
-          - "*"
     ignore:
       - dependency-name: "yiisoft/*"
 
@@ -18,11 +14,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+        interval: "daily"
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 7
-    groups:
-      composer-dependencies:
-        patterns:
-          - "*"
-    versioning-strategy: increase-if-necessary

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -12,4 +12,4 @@ jobs:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
       composer-require-options: '--with-all-dependencies --ignore-platform-req=ext-wincache --no-progress --ansi'
-      php: '["7.4"]'
+      php: '["8.4"]'

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -3,13 +3,12 @@ on:
   push:
 
 name: backwards compatibility
+
+permissions:
+  contents: read
+
 jobs:
-    roave_bc_check:
-        name: Roave BC Check
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@master
-            - name: fetch tags
-              run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-            - name: Roave BC Check
-              uses: docker://nyholm/roave-bc-check-ga
+  roave_bc_check:
+    uses: yiisoft/actions/.github/workflows/bc.yml@master
+    with:
+      php: '["8.4"]'

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -11,4 +11,5 @@ jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
-      php: '["8.4"]'
+      composer-require-options: '--with-all-dependencies --ignore-platform-req=ext-wincache --no-progress --ansi'
+      php: '["7.4"]'

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -11,5 +11,5 @@ jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
-      composer-require-options: '--with-all-dependencies --ignore-platform-req=ext-wincache --no-progress --ansi'
+      composer-require-options: '--with-all-dependencies --ignore-platform-req=ext-wincache --ignore-platform-req=php --no-progress --ansi'
       php: '["8.4"]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ on:
 
 name: build
 
+permissions:
+  contents: read
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -41,10 +43,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -56,7 +60,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -67,15 +71,15 @@ jobs:
         run: composer self-update
 
       - name: Choco install 7zip
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@e80bd39bb49cae70b67ea53d52d00833a7255c21
         with:
           args: install 7zip
 
-      - uses: suisei-cn/actions-download-file@v1
+      - uses: suisei-cn/actions-download-file@8500334edf23d9fb3bd8a6e23e4347d9d3d9e20f
         id: wincache
         name: Download WinCache
         with:
-          url: "https://netcologne.dl.sourceforge.net/project/wincache/development/wincache-2.0.0.8-dev-7.4-nts-vc15-x64.exe"
+          url: "https://downloads.sourceforge.net/project/wincache/development/wincache-2.0.0.8-dev-7.4-nts-vc15-x64.exe"
           target: C:\tools\php\ext
 
       - name: Install WinCache
@@ -96,7 +100,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -19,6 +19,8 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
 jobs:
   mutation:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -38,10 +40,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -53,15 +57,15 @@ jobs:
         run: composer self-update
 
       - name: Choco install 7zip
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@e80bd39bb49cae70b67ea53d52d00833a7255c21
         with:
           args: install 7zip
 
-      - uses: suisei-cn/actions-download-file@v1
+      - uses: suisei-cn/actions-download-file@8500334edf23d9fb3bd8a6e23e4347d9d3d9e20f
         id: wincache
         name: Download WinCache
         with:
-          url: "https://netcologne.dl.sourceforge.net/project/wincache/development/wincache-2.0.0.8-dev-7.4-nts-vc15-x64.exe"
+          url: "https://downloads.sourceforge.net/project/wincache/development/wincache-2.0.0.8-dev-7.4-nts-vc15-x64.exe"
           target: C:\tools\php\ext
 
       - name: Install WinCache
@@ -79,7 +83,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -1,7 +1,7 @@
 name: Rector + PHP CS Fixer
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'src/**'
       - 'tests/**'
@@ -20,8 +20,5 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '7.4'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,6 +21,8 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
 jobs:
   mutation:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -37,10 +39,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
@@ -50,7 +54,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -61,15 +65,15 @@ jobs:
         run: composer self-update
 
       - name: Choco install 7zip
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@e80bd39bb49cae70b67ea53d52d00833a7255c21
         with:
           args: install 7zip
 
-      - uses: suisei-cn/actions-download-file@v1
+      - uses: suisei-cn/actions-download-file@8500334edf23d9fb3bd8a6e23e4347d9d3d9e20f
         id: wincache
         name: Download WinCache
         with:
-          url: "https://netcologne.dl.sourceforge.net/project/wincache/development/wincache-2.0.0.8-dev-7.4-nts-vc15-x64.exe"
+          url: "https://downloads.sourceforge.net/project/wincache/development/wincache-2.0.0.8-dev-7.4-nts-vc15-x64.exe"
           target: C:\tools\php\ext
 
       - name: Install WinCache

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,22 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+  pull_request:
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+
+permissions:
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
+
+jobs:
+  zizmor:
+    uses: yiisoft/actions/.github/workflows/zizmor.yml@master


### PR DESCRIPTION
## Summary
- Pin GitHub Actions and reusable Yii workflow references
- Restrict workflow token permissions where applicable
- Disable checkout credential persistence where it is not needed
- Replace floating latest service images with explicit image refs where zizmor flagged them

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check